### PR TITLE
Add csrfToken generation on non-GET requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,3 @@ app.listen(3000, () => console.log("running"));
 [MIT](https://mit-license.org/)
 
 
-## Special Thanks
-
-[![Jelotti](/img/jelotti-logo.png "Jelotti Logo")](http://jelotti.com)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # `tiny-csrf` 
 
+[![Downloads](https://badgen.net/npm/dt/tiny-csrf)](https://www.npmjs.com/package/tiny-csrf)
+
 This is a tiny csrf library meant to replace what `csurf` used to do
 [before it was deleted](https://github.com/expressjs/csurf). It is
 _almost_ a drop-in replacement.  
@@ -110,6 +112,64 @@ app.post("/", (req, res) => {
 });
 
 app.listen(3000, () => console.log("running"));
+```
+
+## Code Coverage
+
+All contributions must contain [adequeate
+testing](https://github.com/valexandersaulys/tiny-csrf/blob/master/test.js). 
+```
+$ npm run test:coverage
+
+> tiny-csrf@1.1.3 test:coverage
+> nyc --reporter=lcov --reporter=text-summary mocha test.js --exit
+
+
+
+  Cookie Encryption Tests
+    ✔ will encrypt and decrypt a cookie
+
+  Default Options Tests
+    ✔ throw internal error if our secret is not long enough
+    ✔ throws internal error if we have no cookies
+    ✔ generates token for non-POST request
+    ✔ allows if the CSRF token is correct
+    ✔ does not allow if the CSRF token is incorrect
+    ✔ does not allow if the CSRF token is missing in body
+    ✔ does not allow if the CSRF token was never generated
+
+  Tests w/Specified Included Request Methods
+    ✔ allows if the CSRF token is correct
+    ✔ does not allow if the CSRF token is incorrect
+    ✔ allows if the method is specified as not included
+
+  Tests w/Specified Excluded URLs
+    ✔ allows if the URL is marked as excluded
+    ✔ allows if the URL is marked as excluded as a regexp
+    ✔ generates a new token if no token is supplied
+    ✔ does not allow if the CSRF token is incorrect and the URL is not marked as excluded
+
+  Excluded Referrer Tests (Service Workers)
+    ✔ throws error if instantiated without a list as the fourth argument
+    ✔ returns null if a service worker accesses an excluded URL
+    ✔ returns null if we are a service worker
+    ✔ allows for reuse of the CSRF token if there is a service worker request before the real one
+    ✔ allows for reuse of the CSRF token if there is a service worker request after the real one
+
+  other tests
+    ✔ works #1
+    ✔ works #2
+
+
+  22 passing (75ms)
+
+
+=============================== Coverage summary ===============================
+Statements   : 100% ( 59/59 )
+Branches     : 100% ( 30/30 )
+Functions    : 100% ( 8/8 )
+Lines        : 100% ( 54/54 )
+================================================================================
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -46,21 +46,19 @@ const csurf = (secret, forbiddenMethods, excludedUrls, excludedReferers) => {
         verifyCsrf(req.body?._csrf, csrfToken, secret)
       ) {
         res.cookie("csrfToken", null, cookieParams);
-        return next();
       } else {
         throw new Error(
           `Did not get a valid CSRF token for '${req.method} ${req.originalUrl}': ${req.body?._csrf} v. ${csrfToken}`
         );
       }
-    } else {
-      req.csrfToken = () => {
-        if (excludedReferers.includes(req.headers.referer)) return null;
-        const csrfToken = randomUUID();
-        res.cookie("csrfToken", encryptCookie(csrfToken, secret), cookieParams);
-        return csrfToken;
-      };
-      return next();
     }
+    req.csrfToken = () => {
+      if (excludedReferers.includes(req.headers.referer)) return null;
+      const csrfToken = randomUUID();
+      res.cookie("csrfToken", encryptCookie(csrfToken, secret), cookieParams);
+      return csrfToken;
+    };
+    return next();
   };
 };
 

--- a/test.js
+++ b/test.js
@@ -48,7 +48,7 @@ describe("Cookie Encryption Tests", () => {
 describe("Default Options Tests", () => {
   before(() => {
     this.secret = "123456789iamasecret987654321look";
-    this.csrf = csurf(this.secret);
+    this.csrfMiddlware = csurf(this.secret);
   });
 
   it("throw internal error if our secret is not long enough", () => {
@@ -63,7 +63,7 @@ describe("Default Options Tests", () => {
     });
     const next = sinon.stub();
     try {
-      this.csrf(req, res, next);
+      this.csrfMiddlware(req, res, next);
     } catch (err) {
       assert.equal(err.name, "Error", err);
       assert.equal(err.message, "No Cookie middleware is installed");
@@ -80,7 +80,7 @@ describe("Default Options Tests", () => {
     });
     const next = sinon.stub();
     assert.isNotFunction(req.csrfToken);
-    this.csrf(req, res, next);
+    this.csrfMiddlware(req, res, next);
     assert.isFunction(req.csrfToken);
     req.csrfToken();
     assert.isTrue(res.cookie.calledOnce);
@@ -102,8 +102,9 @@ describe("Default Options Tests", () => {
     });
     const next = sinon.stub();
     assert.isNotFunction(req.csrfToken);
-    this.csrf(req, res, next);
+    this.csrfMiddlware(req, res, next);
     assert.isTrue(next.calledOnce);
+    assert.isFunction(req.csrfToken);
   });
   it("does not allow if the CSRF token is incorrect", () => {
     const req = mockRequest({
@@ -121,7 +122,7 @@ describe("Default Options Tests", () => {
     const next = sinon.stub();
     assert.isNotFunction(req.csrfToken);
     try {
-      this.csrf(req, res, next);
+      this.csrfMiddlware(req, res, next);
     } catch (err) {
       assert.equal(err.name, "Error");
       assert.include(err.message, "Did not get a valid CSRF token");
@@ -142,7 +143,7 @@ describe("Default Options Tests", () => {
     const next = sinon.stub();
     assert.isNotFunction(req.csrfToken);
     try {
-      this.csrf(req, res, next);
+      this.csrfMiddlware(req, res, next);
     } catch (err) {
       assert.equal(err.name, "Error");
       assert.include(err.message, "Did not get a valid CSRF token");
@@ -161,7 +162,7 @@ describe("Default Options Tests", () => {
     const next = sinon.stub();
     assert.isNotFunction(req.csrfToken);
     try {
-      this.csrf(req, res, next);
+      this.csrfMiddlware(req, res, next);
     } catch (err) {
       assert.equal(err.name, "Error");
       assert.include(err.message, "Did not get a valid CSRF token");
@@ -173,7 +174,7 @@ describe("Default Options Tests", () => {
 describe("Tests w/Specified Included Request Methods", () => {
   before(() => {
     this.secret = "123456789iamasecret987654321look";
-    this.csrf = csurf(this.secret, ["POST", "PUT"], []);
+    this.csrfMiddlware = csurf(this.secret, ["POST", "PUT"], []);
   });
 
   it("allows if the CSRF token is correct", () => {
@@ -191,7 +192,7 @@ describe("Tests w/Specified Included Request Methods", () => {
     });
     const next = sinon.stub();
     assert.isNotFunction(req.csrfToken);
-    this.csrf(req, res, next);
+    this.csrfMiddlware(req, res, next);
     assert.isTrue(next.calledOnce);
   });
   it("does not allow if the CSRF token is incorrect", () => {
@@ -210,7 +211,7 @@ describe("Tests w/Specified Included Request Methods", () => {
     const next = sinon.stub();
     assert.isNotFunction(req.csrfToken);
     try {
-      this.csrf(req, res, next);
+      this.csrfMiddlware(req, res, next);
     } catch (err) {
       assert.equal(err.name, "Error");
       assert.include(err.message, "Did not get a valid CSRF token");
@@ -232,7 +233,7 @@ describe("Tests w/Specified Included Request Methods", () => {
     });
     const next = sinon.stub();
     assert.isNotFunction(req.csrfToken);
-    this.csrf(req, res, next);
+    this.csrfMiddlware(req, res, next);
     assert.isTrue(next.calledOnce);
   });
 });
@@ -240,7 +241,7 @@ describe("Tests w/Specified Included Request Methods", () => {
 describe("Tests w/Specified Excluded URLs", () => {
   before(() => {
     this.secret = "123456789iamasecret987654321look";
-    this.csrf = csurf(this.secret, null, ["/detail", /\/detail\.*/i]);
+    this.csrfMiddlware = csurf(this.secret, null, ["/detail", /\/detail\.*/i]);
   });
 
   it("allows if the URL is marked as excluded", () => {
@@ -259,7 +260,7 @@ describe("Tests w/Specified Excluded URLs", () => {
     });
     const next = sinon.stub();
     assert.isNotFunction(req.csrfToken);
-    this.csrf(req, res, next);
+    this.csrfMiddlware(req, res, next);
     assert.isTrue(next.calledOnce);
     assert.isFunction(
       req.csrfToken,
@@ -282,7 +283,7 @@ describe("Tests w/Specified Excluded URLs", () => {
     });
     const next = sinon.stub();
     assert.isNotFunction(req.csrfToken);
-    this.csrf(req, res, next);
+    this.csrfMiddlware(req, res, next);
     assert.isTrue(next.calledOnce);
     assert.isFunction(
       req.csrfToken,
@@ -303,7 +304,7 @@ describe("Tests w/Specified Excluded URLs", () => {
     });
     const next = sinon.stub();
     assert.isNotFunction(req.csrfToken);
-    this.csrf(req, res, next);
+    this.csrfMiddlware(req, res, next);
     assert.isTrue(next.calledOnce);
     assert.isFunction(
       req.csrfToken,
@@ -329,7 +330,7 @@ describe("Tests w/Specified Excluded URLs", () => {
     const next = sinon.stub();
     assert.isNotFunction(req.csrfToken);
     try {
-      this.csrf(req, res, next);
+      this.csrfMiddlware(req, res, next);
     } catch (err) {
       assert.equal(err.name, "Error");
       assert.include(err.message, "Did not get a valid CSRF token");
@@ -342,7 +343,7 @@ describe("Excluded Referrer Tests (Service Workers)", () => {
   before(() => {
     this.baseUrl = "http://localhost:3001";
     this.secret = "123456789iamasecret987654321look";
-    this.csrf = csurf(
+    this.csrfMiddlware = csurf(
       this.secret,
       null,
       ["/posts"],
@@ -376,7 +377,7 @@ describe("Excluded Referrer Tests (Service Workers)", () => {
     });
     const next = sinon.stub();
     assert.isNotFunction(req.csrfToken);
-    this.csrf(req, res, next);
+    this.csrfMiddlware(req, res, next);
     assert.isFunction(req.csrfToken);
     const csrfToken = req.csrfToken();
     assert.isNull(csrfToken);
@@ -396,7 +397,7 @@ describe("Excluded Referrer Tests (Service Workers)", () => {
     });
     const next = sinon.stub();
     assert.isNotFunction(req.csrfToken);
-    this.csrf(req, res, next);
+    this.csrfMiddlware(req, res, next);
     assert.isFunction(req.csrfToken);
     const csrfToken = req.csrfToken();
     assert.isNull(csrfToken);
@@ -416,7 +417,7 @@ describe("Excluded Referrer Tests (Service Workers)", () => {
     });
     const nextOne = sinon.stub();
     assert.isNotFunction(reqOne.csrfToken);
-    this.csrf(reqOne, resOne, nextOne);
+    this.csrfMiddlware(reqOne, resOne, nextOne);
     assert.isFunction(reqOne.csrfToken);
     const csrfTokenOne = reqOne.csrfToken();
     assert.isNotNull(csrfTokenOne);
@@ -434,7 +435,7 @@ describe("Excluded Referrer Tests (Service Workers)", () => {
     });
     const next = sinon.stub();
     assert.isNotFunction(req.csrfToken);
-    this.csrf(req, res, next);
+    this.csrfMiddlware(req, res, next);
     assert.isFunction(req.csrfToken);
     const csrfToken = req.csrfToken();
     assert.isNull(csrfToken);
@@ -457,7 +458,7 @@ describe("Excluded Referrer Tests (Service Workers)", () => {
     });
     const nextTwo = sinon.stub();
     assert.isNotFunction(reqTwo.csrfToken);
-    this.csrf(reqTwo, resTwo, nextTwo);
+    this.csrfMiddlware(reqTwo, resTwo, nextTwo);
     assert.isTrue(nextTwo.calledOnce);
   });
   it("allows for reuse of the CSRF token if there is a service worker request after the real one", () => {
@@ -474,7 +475,7 @@ describe("Excluded Referrer Tests (Service Workers)", () => {
     });
     const next = sinon.stub();
     assert.isNotFunction(req.csrfToken);
-    this.csrf(req, res, next);
+    this.csrfMiddlware(req, res, next);
     assert.isFunction(req.csrfToken);
     const csrfToken = req.csrfToken();
     assert.isNull(csrfToken);
@@ -493,7 +494,7 @@ describe("Excluded Referrer Tests (Service Workers)", () => {
     });
     const nextOne = sinon.stub();
     assert.isNotFunction(reqOne.csrfToken);
-    this.csrf(reqOne, resOne, nextOne);
+    this.csrfMiddlware(reqOne, resOne, nextOne);
     assert.isFunction(reqOne.csrfToken);
     const csrfTokenOne = reqOne.csrfToken();
     assert.isNotNull(csrfTokenOne);
@@ -515,7 +516,7 @@ describe("Excluded Referrer Tests (Service Workers)", () => {
     });
     const nextTwo = sinon.stub();
     assert.isNotFunction(reqTwo.csrfToken);
-    this.csrf(reqTwo, resTwo, nextTwo);
+    this.csrfMiddlware(reqTwo, resTwo, nextTwo);
     assert.isTrue(nextTwo.calledOnce);
   });
 });

--- a/test.js
+++ b/test.js
@@ -104,7 +104,10 @@ describe("Default Options Tests", () => {
     assert.isNotFunction(req.csrfToken);
     this.csrfMiddlware(req, res, next);
     assert.isTrue(next.calledOnce);
-    assert.isFunction(req.csrfToken);
+    assert.isFunction(
+      req.csrfToken,
+      "req.csrfToken is not being instantiated on POST requests"
+    );
   });
   it("does not allow if the CSRF token is incorrect", () => {
     const req = mockRequest({

--- a/test.js
+++ b/test.js
@@ -101,13 +101,19 @@ describe("Default Options Tests", () => {
       cookie: sinon.stub()
     });
     const next = sinon.stub();
-    assert.isNotFunction(req.csrfToken);
+    assert.isNotFunction(
+      req.csrfToken,
+      "Generating a csrfToken function before its passed through middleware?"
+    );
+    assert.equal("aaaa", req.body._csrf);
     this.csrfMiddlware(req, res, next);
     assert.isTrue(next.calledOnce);
     assert.isFunction(
       req.csrfToken,
       "req.csrfToken is not being instantiated on POST requests"
     );
+    const myNewToken = req.csrfToken();
+    assert.notEqual(myNewToken, "aaaa", "Not creating a new CSRF token");
   });
   it("does not allow if the CSRF token is incorrect", () => {
     const req = mockRequest({


### PR DESCRIPTION
Per [this issue](https://github.com/valexandersaulys/tiny-csrf/issues/3), I've extended this out to allow for non-GET requests. 

Debating on whether to merge. Can't think of a strong reason not to. This was apparently functionality in the origin library that I had not known. Ultimately the goal of this repo is to recreate it. 